### PR TITLE
Sending kafka test requests via dashboard proxy

### DIFF
--- a/.github/workflows/build-kafka-test-widget.yml
+++ b/.github/workflows/build-kafka-test-widget.yml
@@ -38,7 +38,9 @@ jobs:
         context: ./kafka-test-widget
         platforms: linux/amd64
         push: true
-        tags: ${{ env.REGISTRY_IMAGE }}:build-${{github.run_number}}
+        tags: |
+          ${{ env.REGISTRY_IMAGE }}:latest-build
+          ${{ env.REGISTRY_IMAGE }}:build-${{github.run_number}}
     - name: Optional Push
       if: github.ref == 'refs/heads/main'
       uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ With our Kafka and PinotDB running, we need to:
  * create a Pinot schema and table
 
 
+
 ### Creating the Kafka Topic
 Eventually we'll need this as Infrastructure as Code - perhaps with a K8S Job as part of our Argo deployment or (perhaps better) as an init container for our web test component.
 
@@ -97,6 +98,23 @@ cd kafka-test-widget && make dev
 ![Publish Data](./docs/kafka-test-publish.png)
 
 Success!
+
+
+### Testing
+To confirm the messages are actually being published to Kafka, one easy way to do that is by using the `kafka-console-consumer` (read more at the [Kafka quickstart](https://kafka.apache.org/quickstart)).
+
+We can again open a shell into our Kafka broker and then start a console consumer to listen on our topic:
+
+```
+kafka-console-consumer --bootstrap-server localhost:9092 --from-beginning --property print.key=true --topic user-tracking-data
+```
+
+By using the `--from-beginning` flag, we can see the message(s) we've already published above:
+
+
+```bash
+kafka-console-consumer --bootstrap-server localhost:9092 --from-beginning --property print.key=true --topic user-tracking-data 
+```
 
 ## Setting up Pinot
 

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ echo "   +-------------------------------------------------------+"
 echo "   | all installed! You'll need to create a kafka topic    |"
 echo "   | and create the pinot schema/table. See the readme.md  |"
 echo "   | for more - which just tells you to run the following  |"
-echo "   | after port-forwarding kafka and pinot controller.     |"
+echo "   | after port-forwarding kafka and pinot controller...   |"
 echo "   +-------------------------------------------------------+"
 echo
 echo "open a shell to a kafka broker to run:"

--- a/kafka-test-widget/k8s/web.yaml
+++ b/kafka-test-widget/k8s/web.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: kafka-test-widget-web
-        image: kindservices/datamesh-kafka-test-widget:latest-build
+        image: kindservices/datamesh-kafka-test-widget:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 80

--- a/kafka-test-widget/k8s/web.yaml
+++ b/kafka-test-widget/k8s/web.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: kafka-test-widget-web
-        image: kindservices/datamesh-kafka-test-widget:latest
+        image: kindservices/datamesh-kafka-test-widget:latest-build
         imagePullPolicy: Always
         ports:
         - containerPort: 80

--- a/kafka-test-widget/src/lib/KafkaPost.svelte
+++ b/kafka-test-widget/src/lib/KafkaPost.svelte
@@ -1,6 +1,6 @@
 <svelte:options tag="kafka-test-widget" />
 <script type="ts">
-    import {kafkaHost} from './settings'
+    import {publishToKafka} from './kafkaRestClient'
     
     let topic = 'user-tracking-data';
     let slug = '/foo/bar';
@@ -42,20 +42,9 @@
   
     const postMessage = async () => {
       try {
-
         // refresh our timestamp
         record.timestampInEpoch = Date.now();
-        const response = await fetch(`${kafkaHost}/topics/${topic}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/vnd.kafka.json.v2+json',
-          },
-          body: JSON.stringify({
-            records: [
-              { key: `key-${record.timestampInEpoch}`, value: record } 
-            ],
-          }),
-        });
+        const response = await publishToKafka(topic, `key-${record.timestampInEpoch}`, record)
   
         if (!response.ok) {
           userMessage = 'Failed to post message to Kafka:' + response.statusText;
@@ -73,7 +62,7 @@
   </script>
   
   <main>
-    <h1>Post Message to {kafkaHost}</h1>
+    <h1>Post Message</h1>
     <div class='form'>
       <div class="field">Topic: <input type="text" bind:value={topic} /></div>
       <div class="field">hostname: <input type="text" bind:value={hostname} /></div>
@@ -120,21 +109,20 @@
     }
     .form {
       display: flex;
-      align-items: baseline;
+      align-items: center; 
     }
     .field {
       flex-direction: column;
     }
     main {
+      align-items: stretch; 
+      display: flex;
+      flex-direction: column;
       vertical-align: top;
       padding: 1em;
       max-width: 240px;
       margin: 0 auto;
     }
   
-    textarea {
-      width: 100%;
-      margin-bottom: 1em;
-    }
   </style>
   

--- a/kafka-test-widget/src/lib/kafkaRestClient.ts
+++ b/kafka-test-widget/src/lib/kafkaRestClient.ts
@@ -1,0 +1,54 @@
+import {kafkaHost, kafkaK8SHost} from './settings'
+
+const KafkaHeaders = { 'Content-Type': 'application/vnd.kafka.json.v2+json' }
+
+export const publishToKafka = async (topic, key, record) => {
+    // this is a bit sloppy / wasteful, but it's an ugly way to 
+    // try to publish kafka messages EITHER via a kafka-proxy directly OR
+    // vai the dashboard proxy  
+    const promise1 = publishViaProxy(topic, key, record)
+    const promise2 = publishToKafkaDirectly(topic, key, record)
+    return Promise.race([promise1, promise2])
+}
+
+const kafkaMsg = (key, record) => {
+    return { records: [ { key: key, value: record }  ] }
+}
+
+
+// this function publishes directly to a Kafka REST proxy
+export const publishViaProxy = async (topic, key, record) => {
+    const proxyRequestBody = {
+        proxy: `${kafkaK8SHost}/topics/${topic}`,
+        method: "POST",
+        headers: KafkaHeaders,
+        body: kafkaMsg(key, record)
+    }
+    return fetch(`/api/proxy`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(proxyRequestBody)
+      }).then((result) => {
+        console.log(`POST to ${kafkaK8SHost}/topics/${topic} via /api/proxy ${result.ok ? "succeeded" : "failed"}:`, result);
+        return result
+      })
+}
+
+
+// this function publishes directly to a Kafka REST proxy
+export const publishToKafkaDirectly = async (topic, key, record) => {
+    return fetch(`${kafkaHost}/topics/${topic}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/vnd.kafka.json.v2+json',
+        },
+        body: JSON.stringify({
+          records: [
+            { key: key, value: record } 
+          ],
+        }),
+      }).then((result) => {
+        console.log(`POST to ${kafkaHost}/topics/${topic} ${result.ok ? "succeeded" : "failed"}:`, result);
+        return result
+      })
+}

--- a/kafka-test-widget/src/lib/settings.js
+++ b/kafka-test-widget/src/lib/settings.js
@@ -2,5 +2,12 @@ export const kafkaLocalHost = "http://localhost:8082"
 export const kafkaK8SHost = "http://kafka-service:8082"
 const host = window.location.hostname;
 const isLocalHost = host.indexOf("127.0.0.1") >= 0
+
+// we're being a bit clever here -- using a local port-forward
+// when running on localhost (e.g. 127.0.0.1). 
 export const kafkaHost = (isLocalHost) ? kafkaLocalHost : kafkaK8SHost
+
+// our dashboard proxy, if we need to send messages to Kafka via our dashboard
+export const proxyHost = (isLocalHost) ? "http://localhost:3000" : "http://dashboard-web.data-mesh:3000"
+
 console.log("host is " + host + ", isLocalHost is " + isLocalHost + ", kafkaHost is " + kafkaHost);

--- a/kafka-test-widget/src/lib/settings.js
+++ b/kafka-test-widget/src/lib/settings.js
@@ -1,5 +1,5 @@
 export const kafkaLocalHost = "http://localhost:8082"
-export const kafkaK8SHost = "http://kafka-service:8082"
+export const kafkaK8SHost = "http://kafka-rest-proxy.default.svc.cluster.local:8082"
 const host = window.location.hostname;
 const isLocalHost = host.indexOf("127.0.0.1") >= 0
 


### PR DESCRIPTION
We POST to the dashboard AND the kafka-rest proxy, racing the responses.

It's ugly and wasteful, but it works for both our scenarios of direct posting to Kafka-REST and via the dashboard proxy